### PR TITLE
keep np.array(out_bboxes) before try/except 

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -378,10 +378,11 @@ class Yolo_dataset(Dataset):
         if use_mixup == 3:
             out_bboxes = np.concatenate(out_bboxes, axis=0)
         out_bboxes1 = np.zeros([self.cfg.boxes, 5])
+        
+        out_bboxes = np.array(out_bboxes, dtype=np.float32)
         try:
             out_bboxes1[:min(out_bboxes.shape[0], self.cfg.boxes)] = out_bboxes[:min(out_bboxes.shape[0], self.cfg.boxes)]
         except AttributeError:
-            out_bboxes = np.array(out_bboxes, dtype=np.float32)
             out_bboxes1[:min(out_bboxes.shape[0], self.cfg.boxes)] = out_bboxes[:min(out_bboxes.shape[0], self.cfg.boxes)]
         return out_img, out_bboxes1
 


### PR DESCRIPTION
Hello there,

I received an error using your code(found both an attribute and value error, and i guess the value error stemmed from the attribute error). I solved this by moving the np.array section outside of the try-catch loop so that no matter what the data will have a shape attribute.

hope it works!