### PR TITLE
Fix ValueError: could not broadcast input array from shape

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -381,7 +381,7 @@ class Yolo_dataset(Dataset):
         try:
             out_bboxes1[:min(out_bboxes.shape[0], self.cfg.boxes)] = out_bboxes[:min(out_bboxes.shape[0], self.cfg.boxes)]
         except AttributeError:
-            out_bboxes = np.array(out_bboxes, dtype=np.float32)
+            out_bboxes = np.array(out_bboxes.astype(object), dtype=np.float32)
             out_bboxes1[:min(out_bboxes.shape[0], self.cfg.boxes)] = out_bboxes[:min(out_bboxes.shape[0], self.cfg.boxes)]
         return out_img, out_bboxes1
 


### PR DESCRIPTION
I am training YOLOv4 with EgoHands Generic Dataset provided by Roboflow and stumbling with this exception. This error happens since elements in the out_bboxes array do not have the same type (following this Stackoverflow thread https://stackoverflow.com/questions/43977463/valueerror-could-not-broadcast-input-array-from-shape-224-224-3-into-shape-2).